### PR TITLE
fix: PyInstaller bundle stuck on splash screen (tiktoken namespace package)

### DIFF
--- a/backend/utils/token_utils.py
+++ b/backend/utils/token_utils.py
@@ -5,10 +5,12 @@ from __future__ import annotations
 import logging
 
 import tiktoken
+from tiktoken.core import Encoding
+from tiktoken_ext.openai_public import cl100k_base as _cl100k_base_constructor
 
 logger = logging.getLogger("token_utils")
 
-_tokenizer = tiktoken.get_encoding("cl100k_base")
+_tokenizer = Encoding(**_cl100k_base_constructor())
 
 
 def count_tokens(text: str) -> int:

--- a/build/winkterm.spec
+++ b/build/winkterm.spec
@@ -141,6 +141,9 @@ a = Analysis(
         "pydantic_settings",
         # websockets
         "websockets",
+        # tiktoken
+        "tiktoken_ext",
+        "tiktoken_ext.openai_public",
     ],
     hookspath=[],
     hooksconfig={},
@@ -202,7 +205,7 @@ elif IS_MACOS:
         bootloader_ignore_signals=False,
         strip=False,
         upx=True,
-        console=False,
+        console=True,
         disable_windowed_traceback=False,
         argv_emulation=False,
         target_arch=None,


### PR DESCRIPTION
## 问题

macOS 桌面应用打包后卡在启动页，后端无法启动。

## 根因

`tiktoken` 使用 `tiktoken_ext` 命名空间包做插件发现（`pkgutil.iter_modules`），PyInstaller 的 PYZ 存档中命名空间包子模块不可发现，导致 `cl100k_base` 编码构造函数注册失败，后端抛出 `ValueError: Unknown encoding cl100k_base` 异常。

## 修复

1. **`backend/utils/token_utils.py`** — 直接从 `tiktoken_ext.openai_public` 导入构造函数并手动调用，绕过 registry 的插件发现机制
2. **`build/winkterm.spec`** — 添加 `tiktoken_ext` / `tiktoken_ext.openai_public` 到 hidden imports；macOS 启用 `console=True` 便于调试

## 验证

在构建后的 `WinkTerm.app` 中测试通过：健康检查成功、Agent 加载、WebSocket 连接、PTY 创建均正常。