### PR TITLE
docs: move Chinese README link to top

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
 <div align="center">
+
+[中文版本](README.zh-CN.md)
+
+</div>
+
+<div align="center">
   <img src="assets/logo.svg" alt="WinkTerm Logo" width="120"/>
   <h1>WinkTerm</h1>
   <p><strong>AI that shares your terminal session.</strong></p>


### PR DESCRIPTION
将中文版本 README 链接移至 README 最开头，方便中文用户快速发现。