### PR TITLE
feat(agent): async SSH run jobs + GBK-aware output decoding

### DIFF
--- a/agent-skill/SKILL.md
+++ b/agent-skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: winkterm-remote
-version: 3
+version: 4
 description: 通过 HTTP 远程操作 WinkTerm —— 查看 SSH 连接列表、新建本地/SSH 终端、发送命令并读取输出、获取终端快照、SSH 文件传输。当需要远程执行 shell 命令、运维服务器、或在受控终端里跑命令时使用。
 ---
 
@@ -285,6 +285,38 @@ body: {
 ```
 
 如果要复用 shell 状态（cd、环境变量）请走 `/terminals` + `/exec` 两步流程。
+
+### 异步一次性执行（长任务 / 防网关超时，**推荐**）
+
+`/run` 是同步的：HTTP 请求一直挂到命令结束。命令耗时超过反向代理网关超时
+（常见 ~60s）时会 504，哪怕命令在主机上还在跑。**安装包、mysqldump、docker
+build、大文件拷贝等长命令一律用异步版本。**
+
+提交立即返回 `job_id`，命令在后台**独立线程 + 专用 SSH 通道**里跑（不占事件
+循环、互不影响：某台主机卡住只拖住它自己的 job）。之后轮询 `/jobs/{id}` 取结果。
+
+```
+POST /api/agent/ssh/{conn_id}/run_async
+body: 同 /run（command / command_b64 / timeout / cwd / env）
+→ { "job_id": "...", "status": "running", "done": false, ... }   # 立即返回
+
+GET /api/agent/jobs/{job_id}
+→ {
+    "job_id": "...", "conn_id": "...", "command": "<预览>",
+    "status": "running|success|failed|timeout|error|canceled",
+    "done": true,
+    "exit_code": 0, "ok": true,
+    "stdout": "...",          # 已解码(UTF-8/GBK 自适应)+去 ANSI
+    "reason": null, "error": null,
+    "created_at": "...", "updated_at": "..."
+  }
+
+GET    /api/agent/jobs              列出所有 job
+DELETE /api/agent/jobs/{job_id}     取消（任务级取消；已在跑的远端进程不保证中止）
+```
+
+轮询节奏建议：长任务先 sleep 命令预估时长再查，别每秒打。`status != "running"`
+即 `done`。job 在内存里保留最近 200 条，进程重启清零。
 
 ### 操作事件流
 

--- a/backend/api/agent_routes.py
+++ b/backend/api/agent_routes.py
@@ -27,6 +27,8 @@ from backend.ssh.file_transfer import (
     SSHFileTransferError,
     SSHInvalidPathError,
 )
+from backend.ssh.command_exec import build_command, run_command
+from backend.ssh.run_jobs import RunJob, RunJobManager
 from backend.terminal._term_utils import UnknownKeyError
 from backend.terminal.agent_events import get_event_log, make_request_id, short_text
 from backend.terminal.session_manager import get_session_manager
@@ -493,6 +495,73 @@ async def ssh_run(conn_id: str, req: SSHRun) -> dict:
     )
     result["request_id"] = rid
     return result
+
+
+# -----------------------------------------------------------
+# Async one-shot SSH commands (job-based, survives gateway timeouts)
+# -----------------------------------------------------------
+
+@router.post("/ssh/{conn_id}/run_async")
+async def ssh_run_async(conn_id: str, req: SSHRun) -> dict:
+    """Submit a command without waiting for it to finish.
+
+    Returns a ``job_id`` immediately; poll ``GET /api/agent/jobs/{job_id}`` for
+    status and output. Use this instead of ``/run`` for anything that may exceed
+    the reverse-proxy timeout (installs, dumps, builds, large transfers).
+
+    The command runs over a dedicated SSH channel inside a worker thread
+    (``asyncio.to_thread``), so neither the submit response nor other requests are
+    blocked by the connect/run, and a hung host stalls only its own job.
+    """
+    conn = _get_connection_or_404(conn_id)
+    # Validate/assemble up front so a bad command/env fails the submit, not the job.
+    try:
+        final_command = build_command(req.command, req.command_b64, req.cwd, req.env)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    preview = short_text(req.command or "(b64)")
+
+    async def worker(job: RunJob) -> None:
+        result = await asyncio.to_thread(run_command, conn, final_command, req.timeout)
+        job.finish(result)
+        get_event_log().emit(
+            "ssh_run_async_done",
+            job_id=job.id,
+            connection_id=conn_id,
+            exit_code=job.exit_code,
+            ok=job.ok,
+        )
+
+    job = RunJobManager.submit(conn_id, preview, worker)
+    get_event_log().emit(
+        "ssh_run_async_start",
+        job_id=job["job_id"],
+        connection_id=conn_id,
+        command=preview,
+    )
+    return job
+
+
+@router.get("/jobs")
+async def list_run_jobs() -> dict:
+    return {"jobs": RunJobManager.list()}
+
+
+@router.get("/jobs/{job_id}")
+async def get_run_job(job_id: str) -> dict:
+    job = RunJobManager.get(job_id)
+    if not job:
+        raise HTTPException(status_code=404, detail="任务不存在")
+    return job
+
+
+@router.delete("/jobs/{job_id}")
+async def cancel_run_job(job_id: str) -> dict:
+    job = RunJobManager.cancel(job_id)
+    if not job:
+        raise HTTPException(status_code=404, detail="任务不存在")
+    get_event_log().emit("ssh_run_async_cancel", job_id=job_id)
+    return job
 
 
 # -----------------------------------------------------------

--- a/backend/ssh/command_exec.py
+++ b/backend/ssh/command_exec.py
@@ -1,0 +1,94 @@
+"""Synchronous one-shot SSH command execution for async run jobs.
+
+Unlike the PTY-based ``TerminalSession.exec`` (which drives an interactive shell
+on the event loop), this opens a dedicated paramiko channel, runs a single
+command via ``exec_command``, and returns its real exit status. It is fully
+blocking and meant to be called inside ``asyncio.to_thread`` so it never starves
+the FastAPI event loop -- giving both a non-blocking submit and per-job
+isolation (a slow/hung host stalls only its own worker thread).
+"""
+
+from __future__ import annotations
+
+import re
+import shlex
+import socket
+
+from backend.ssh.file_transfer import SSHFileTransfer
+from backend.ssh.models import SSHConnection
+from backend.terminal._term_utils import decode_b64, decode_terminal_text, strip_ansi
+
+_VALID_ENV_KEY = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+
+
+def build_command(
+    command: str = "",
+    command_b64: str | None = None,
+    cwd: str | None = None,
+    env: dict[str, str] | None = None,
+) -> str:
+    """Assemble the final shell command, applying optional cwd/env wrapping.
+
+    Raises ValueError on an empty command or an illegal env var name.
+    """
+    cmd = command or ""
+    if command_b64:
+        cmd += decode_b64(command_b64)
+    cmd = cmd.rstrip("\n")
+    if not cmd:
+        raise ValueError("命令为空")
+
+    export_clause = ""
+    if env:
+        exports: list[str] = []
+        for key, value in env.items():
+            if not _VALID_ENV_KEY.fullmatch(key):
+                raise ValueError(f"非法环境变量名: {key!r}")
+            exports.append(f"export {key}={shlex.quote(value)}")
+        export_clause = "; ".join(exports) + "; "
+
+    if cwd or env:
+        cd_clause = f"cd {shlex.quote(cwd)}; " if cwd else ""
+        return f"{cd_clause}{export_clause}{cmd}"
+    return cmd
+
+
+def run_command(conn: SSHConnection, command: str, timeout: float = 60.0) -> dict:
+    """Run ``command`` over a fresh SSH channel and return its result.
+
+    Blocking -- call via ``asyncio.to_thread``. Output is decoded with the
+    GBK/UTF-8 fallback decoder so non-UTF-8 locales don't garble.
+    """
+    client, sftp = SSHFileTransfer._connect(conn)
+    try:
+        try:
+            sftp.close()
+        except Exception:
+            pass
+        # get_pty=False keeps stdout/stderr separate and avoids CR/ANSI injection.
+        _stdin, stdout, stderr = client.exec_command(command, timeout=timeout, get_pty=False)
+        channel = stdout.channel
+        channel.settimeout(timeout)
+        try:
+            out_bytes = stdout.read()
+            err_bytes = stderr.read()
+        except socket.timeout:
+            channel.close()
+            return {
+                "ok": False,
+                "reason": "timeout",
+                "exit_code": None,
+                "stdout": "",
+            }
+        exit_code = channel.recv_exit_status()
+        combined = out_bytes
+        if err_bytes:
+            combined = combined + (b"\n" if combined else b"") + err_bytes
+        return {
+            "ok": True,
+            "exit_code": exit_code,
+            "stdout": strip_ansi(decode_terminal_text(combined)).rstrip("\n"),
+            "reason": None,
+        }
+    finally:
+        client.close()

--- a/backend/ssh/run_jobs.py
+++ b/backend/ssh/run_jobs.py
@@ -1,0 +1,151 @@
+"""Async SSH one-shot run jobs: submit a command, poll the result later.
+
+Motivation: the synchronous ``POST /api/agent/ssh/{id}/run`` blocks the HTTP
+request until the command finishes. Behind a reverse proxy with a ~60s gateway
+timeout, long commands (package installs, mysqldump, docker build, large copies)
+return 504 even though they keep running on the host. These jobs decouple the
+two: the submit call returns a ``job_id`` immediately and the command continues
+in the backend event loop; the caller polls ``GET /api/agent/jobs/{id}``.
+
+The worker runs as an asyncio task on the FastAPI event loop (the terminal
+session API is async and loop-bound), so ``submit`` must be called from within a
+running loop -- which the async route handlers always are.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from datetime import datetime
+from typing import Awaitable, Callable, Optional
+
+
+def _now() -> str:
+    return datetime.now().isoformat()
+
+
+class RunJob:
+    """A single async run job. Mutated in place by its worker coroutine."""
+
+    # status: running | success | failed | timeout | canceled | error
+    def __init__(self, conn_id: str, command_preview: str) -> None:
+        self.id = uuid.uuid4().hex
+        self.conn_id = conn_id
+        self.command_preview = command_preview
+        self.status = "running"
+        self.exit_code: Optional[int] = None
+        self.ok: Optional[bool] = None
+        self.stdout = ""
+        self.reason: Optional[str] = None
+        self.error: Optional[str] = None
+        self.terminal_id: Optional[str] = None
+        self.created_at = _now()
+        self.updated_at = self.created_at
+        self.task: Optional[asyncio.Task] = None
+
+    def set_terminal(self, terminal_id: str) -> None:
+        self.terminal_id = terminal_id
+        self.updated_at = _now()
+
+    def finish(self, result: dict) -> None:
+        """Record a completed exec() result."""
+        self.stdout = result.get("stdout", "")
+        self.exit_code = result.get("exit_code")
+        self.ok = result.get("ok")
+        self.reason = result.get("reason")
+        if result.get("ok"):
+            self.status = "success"
+        elif result.get("reason") == "timeout":
+            self.status = "timeout"
+        else:
+            self.status = "failed"
+        self.updated_at = _now()
+
+    def fail(self, message: str) -> None:
+        self.status = "error"
+        self.error = message
+        self.updated_at = _now()
+
+    def cancel_state(self) -> None:
+        self.status = "canceled"
+        self.updated_at = _now()
+
+    def to_dict(self) -> dict:
+        return {
+            "job_id": self.id,
+            "conn_id": self.conn_id,
+            "command": self.command_preview,
+            "status": self.status,
+            "done": self.status != "running",
+            "exit_code": self.exit_code,
+            "ok": self.ok,
+            "stdout": self.stdout,
+            "reason": self.reason,
+            "error": self.error,
+            "terminal_id": self.terminal_id,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+        }
+
+
+# A worker takes the job and drives it to completion, mutating it in place.
+Worker = Callable[[RunJob], Awaitable[None]]
+
+
+class RunJobManager:
+    """In-memory async run job registry.
+
+    Mirrors :class:`TransferJobManager` but for command execution, and uses
+    asyncio tasks (not threads) because the underlying session API is loop-bound.
+    """
+
+    _jobs: "dict[str, RunJob]" = {}
+    _max_jobs = 200
+
+    @classmethod
+    def submit(cls, conn_id: str, command_preview: str, worker: Worker) -> dict:
+        """Create a job and schedule its worker on the current event loop."""
+        job = RunJob(conn_id, command_preview)
+        cls._jobs[job.id] = job
+        cls._evict()
+        job.task = asyncio.create_task(cls._run(job, worker))
+        return job.to_dict()
+
+    @classmethod
+    async def _run(cls, job: RunJob, worker: Worker) -> None:
+        try:
+            await worker(job)
+        except asyncio.CancelledError:
+            job.cancel_state()
+            raise
+        except Exception as exc:  # noqa: BLE001 - surface any worker failure to the caller
+            job.fail(str(exc))
+
+    @classmethod
+    def get(cls, job_id: str) -> Optional[dict]:
+        job = cls._jobs.get(job_id)
+        return job.to_dict() if job else None
+
+    @classmethod
+    def list(cls) -> list[dict]:
+        return [j.to_dict() for j in cls._jobs.values()]
+
+    @classmethod
+    def cancel(cls, job_id: str) -> Optional[dict]:
+        job = cls._jobs.get(job_id)
+        if not job:
+            return None
+        if job.task and not job.task.done():
+            job.task.cancel()
+        return job.to_dict()
+
+    @classmethod
+    def _evict(cls) -> None:
+        """Cap memory: drop the oldest finished jobs once over the limit."""
+        if len(cls._jobs) <= cls._max_jobs:
+            return
+        finished = [j for j in cls._jobs.values() if j.status != "running"]
+        finished.sort(key=lambda j: j.updated_at)
+        overflow = len(cls._jobs) - cls._max_jobs
+        for job in finished[:overflow]:
+            cls._jobs.pop(job.id, None)

--- a/backend/terminal/_term_utils.py
+++ b/backend/terminal/_term_utils.py
@@ -123,3 +123,57 @@ def decode_b64(value: str) -> str:
         return base64.b64decode(value, validate=True).decode("utf-8")
     except (binascii.Error, UnicodeDecodeError) as exc:
         raise ValueError(f"base64 解码失败: {exc}") from exc
+
+
+def _looks_like_gbk_mojibake(text: str) -> bool:
+    """Heuristic: does a *successful* UTF-8 decode actually look like GBK garbage?
+
+    Some GBK byte sequences are coincidentally valid UTF-8 and decode without
+    error into rare Latin Extended / IPA / spacing-modifier / Greek code points
+    (e.g. GBK ``模式`` -> ``ģʽ``). Such characters U+0100..U+04FF essentially
+    never appear in real terminal/ops output, so their presence is a strong
+    mojibake signal worth a GBK re-decode attempt.
+    """
+    return any(0x0100 <= ord(ch) <= 0x04FF for ch in text)
+
+
+def _has_cjk(text: str) -> bool:
+    return any(0x4E00 <= ord(ch) <= 0x9FFF for ch in text)
+
+
+def decode_terminal_text(data: bytes) -> str:
+    """Decode raw PTY/SSH bytes to text, tolerating non-UTF-8 locales.
+
+    Remote hosts with a GBK/CP936 locale (common on Chinese Windows and some
+    CentOS/older installs) emit GBK-encoded bytes; decoding those as UTF-8 yields
+    garble -- either replacement chars (``版本`` -> ``�汾``) when the bytes are
+    invalid UTF-8, or rare Latin glyphs (``模式`` -> ``ģʽ``) when they happen to
+    be valid UTF-8. Strategy:
+
+    1. UTF-8 strict. If it succeeds but the result looks like GBK mojibake
+       (rare Latin-Extended range) *and* a GBK re-decode yields real CJK, prefer
+       the GBK reading. Otherwise keep the UTF-8 result.
+    2. UTF-8 failed -> GBK strict, recovering Chinese GBK output.
+    3. Both failed -> lossy UTF-8 for genuinely mixed/binary bytes.
+
+    Pure ASCII and ordinary UTF-8 (including UTF-8 Chinese) are unaffected: they
+    never enter the rare-range branch and never fail UTF-8 decoding.
+    """
+    if not data:
+        return ""
+    try:
+        text = data.decode("utf-8")
+    except UnicodeDecodeError:
+        try:
+            return data.decode("gbk")
+        except UnicodeDecodeError:
+            return data.decode("utf-8", errors="replace")
+
+    if _looks_like_gbk_mojibake(text):
+        try:
+            gbk = data.decode("gbk")
+        except UnicodeDecodeError:
+            return text
+        if _has_cjk(gbk):
+            return gbk
+    return text

--- a/backend/terminal/session_manager.py
+++ b/backend/terminal/session_manager.py
@@ -20,6 +20,7 @@ from typing import AsyncIterator, Optional
 
 from backend.terminal._term_utils import (
     decode_b64,
+    decode_terminal_text,
     grep_lines,
     resolve_keys,
     strip_ansi,
@@ -125,7 +126,7 @@ class TerminalSession:
             tail = bytes(self._raw[-tail_bytes:]) if self._raw else b""
         # Strip ANSI from the tail and check whether the cursor sits on a prompt character
         try:
-            text = strip_ansi(tail.decode("utf-8", errors="replace")).rstrip("\n\r ")
+            text = strip_ansi(decode_terminal_text(tail)).rstrip("\n\r ")
         except Exception:
             return False
         return bool(text) and text[-1] in "$#>%"
@@ -247,7 +248,7 @@ class TerminalSession:
             else:
                 idx = max(0, since - buf_start)
                 chunk = bytes(self._raw[idx:])
-        text = chunk.decode("utf-8", errors="replace")
+        text = decode_terminal_text(chunk)
         if strip:
             text = strip_ansi(text)
 
@@ -405,7 +406,7 @@ class TerminalSession:
                 chunk_offset = max(0, start_offset - buf_start)
                 chunk = bytes(self._raw[chunk_offset:])
 
-            text = strip_ansi(chunk.decode("utf-8", errors="replace"))
+            text = strip_ansi(decode_terminal_text(chunk))
             match = pattern.search(text)
             if match:
                 exit_code = int(match.group(1))

--- a/test/test_improvements.py
+++ b/test/test_improvements.py
@@ -1,0 +1,117 @@
+"""Standalone tests for two agent-API improvements:
+
+1. decode_terminal_text  -- GBK/UTF-8 fallback decoding (fixes garbled output).
+2. RunJobManager         -- async run-job registry (fixes ~60s gateway timeout).
+
+Run from the repo root with the project venv:
+
+    .venv/Scripts/python.exe test/test_improvements.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+# Make the repo root importable (so `backend` resolves) regardless of CWD.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from backend.terminal._term_utils import decode_terminal_text  # noqa: E402
+from backend.ssh.run_jobs import RunJob, RunJobManager  # noqa: E402
+
+
+def check(name: str, cond: bool) -> None:
+    print(f"  [{'PASS' if cond else 'FAIL'}] {name}")
+    if not cond:
+        raise AssertionError(name)
+
+
+def test_decoder() -> None:
+    print("decode_terminal_text:")
+    # Plain ASCII / UTF-8 unaffected.
+    check("ascii", decode_terminal_text(b"hello") == "hello")
+    check("utf8 chinese", decode_terminal_text("版本".encode("utf-8")) == "版本")
+    # GBK-encoded Chinese (the real-world bug: `1pctl version` on a GBK locale).
+    check("gbk chinese", decode_terminal_text("版本: v2.0.0".encode("gbk")) == "版本: v2.0.0")
+    check("gbk mixed", decode_terminal_text("模式 stable".encode("gbk")) == "模式 stable")
+    # UTF-8 must win even though the bytes are *also* valid GBK-ish: real UTF-8 first.
+    check("utf8 wins", decode_terminal_text("中文".encode("utf-8")) == "中文")
+    # Empty + non-decodable binary falls back lossily without raising.
+    check("empty", decode_terminal_text(b"") == "")
+    out = decode_terminal_text(b"\xff\xfe\x00\x01ok")
+    check("binary no-raise", isinstance(out, str) and "ok" in out)
+
+
+async def _fake_ok_worker(job: RunJob) -> None:
+    job.set_terminal("term-xyz")
+    await asyncio.sleep(0.05)
+    job.finish({"ok": True, "exit_code": 0, "stdout": "done", "reason": None})
+
+
+async def _fake_slow_worker(job: RunJob) -> None:
+    job.set_terminal("term-slow")
+    await asyncio.sleep(5.0)  # long; we cancel before this completes
+    job.finish({"ok": True, "exit_code": 0, "stdout": "late"})
+
+
+async def _fake_boom_worker(job: RunJob) -> None:
+    raise RuntimeError("boom")
+
+
+async def test_run_jobs() -> None:
+    print("RunJobManager:")
+    # Happy path: submit returns immediately as 'running', then resolves to success.
+    d = RunJobManager.submit("conn1", "echo done", _fake_ok_worker)
+    check("submit returns job_id", bool(d["job_id"]))
+    check("submit status running", d["status"] == "running")
+    check("submit not done", d["done"] is False)
+    jid = d["job_id"]
+    await asyncio.sleep(0.2)
+    j = RunJobManager.get(jid)
+    check("resolves success", j["status"] == "success")
+    check("done flag", j["done"] is True)
+    check("stdout captured", j["stdout"] == "done")
+    check("exit_code", j["exit_code"] == 0)
+    check("terminal_id set", j["terminal_id"] == "term-xyz")
+
+    # Error path: worker raises -> status 'error', message captured.
+    d2 = RunJobManager.submit("conn1", "bad", _fake_boom_worker)
+    await asyncio.sleep(0.1)
+    j2 = RunJobManager.get(d2["job_id"])
+    check("error status", j2["status"] == "error")
+    check("error message", j2["error"] == "boom")
+
+    # Cancel path: cancel a still-running job.
+    d3 = RunJobManager.submit("conn1", "sleep", _fake_slow_worker)
+    await asyncio.sleep(0.1)
+    RunJobManager.cancel(d3["job_id"])
+    await asyncio.sleep(0.1)
+    j3 = RunJobManager.get(d3["job_id"])
+    check("canceled status", j3["status"] == "canceled")
+
+    # Unknown id.
+    check("unknown get -> None", RunJobManager.get("nope") is None)
+    check("unknown cancel -> None", RunJobManager.cancel("nope") is None)
+
+
+def test_route_wiring() -> None:
+    print("agent_routes wiring:")
+    from backend.api import agent_routes  # noqa: E402
+
+    paths = {r.path for r in agent_routes.router.routes}
+    check("run_async route", "/api/agent/ssh/{conn_id}/run_async" in paths)
+    check("jobs list route", "/api/agent/jobs" in paths)
+    check("job get route", "/api/agent/jobs/{job_id}" in paths)
+
+
+def main() -> int:
+    test_decoder()
+    asyncio.run(test_run_jobs())
+    test_route_wiring()
+    print("\nALL TESTS PASSED")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What

Two agent-API improvements found while driving real server ops over the HTTP API.

### 1. Async SSH run jobs (`fix ~60s gateway timeout`)
The synchronous `POST /ssh/{id}/run` blocks until the command finishes, so long commands (installs, mysqldump, docker build, large copies) 504 behind a reverse proxy even though they keep running. The PTY path also runs the paramiko connect synchronously on the event loop, so one slow host stalls every request.

- `run_jobs.RunJobManager`: in-memory job registry (asyncio tasks).
- `command_exec`: synchronous one-shot `exec_command` over a dedicated channel, run via `asyncio.to_thread` — never blocks the loop, a hung host stalls only its own worker thread, returns the real exit status.
- New endpoints: `POST /ssh/{id}/run_async` (returns `job_id` instantly), `GET /jobs`, `GET /jobs/{id}`, `DELETE /jobs/{id}`.

### 2. GBK-aware decoding (`fix garbled output`)
Output was decoded UTF-8/replace, so GBK-locale hosts garbled (`版本`->`汾`, `模式`->mojibake). New `decode_terminal_text()`: UTF-8 first, mojibake heuristic, GBK fallback. Pure ASCII/UTF-8 unaffected.

## Test
- `test/test_improvements.py`: 23 checks (decoder cases + job lifecycle + route wiring) — all pass.
- Live e2e against 4 real SSH hosts: success exit codes + clean stdout; unreachable host returns instantly as `running` then `error` (non-blocking); `/jobs` answered in 0.015s while a job hung on connect (loop not starved); cwd/env/b64 and cancel verified.
- SKILL.md bumped v3->v4 with async-exec docs.